### PR TITLE
Exclude migrations from black formatter

### DIFF
--- a/Python/pre-commit
+++ b/Python/pre-commit
@@ -32,7 +32,7 @@ fi
 # changes.
 echo 'Formatting staged Python files . . .'
 # formatting with black
-black . --include ${PYTHON_FILES[@]}
+black . --include ${PYTHON_FILES[@]} --exclude migrations/.*\.py
 
 
 CHANGED_FILES=(`git diff --name-only ${PYTHON_FILES[@]}`)


### PR DESCRIPTION
Added a regex pattern to the Python pre commit hook for black to exclude migration files.